### PR TITLE
[woocommerce] Fix integration with Variable Products

### DIFF
--- a/src/loaders/data-simulator.js
+++ b/src/loaders/data-simulator.js
@@ -38,7 +38,7 @@ module.exports = function (aplazame) {
     '#product-info .special-price .price', // magento
     '#product-info .regular-price .price', // magento
     'form#buy_block #our_price_display', // prestashop
-    '#main [itemtype="http://schema.org/Product"] [itemtype="http://schema.org/Offer"] .price .amount' // woocommerce
+    '#main [itemtype="http://schema.org/Product"] .price .amount' // woocommerce
   ],
   cmsQtySelector = [
     'form#product_addtocart_form input[name="qty"]', // magento


### PR DESCRIPTION
WooCommerce use a different markup while selecting the variations for a product.

At begin WooCommerce display a range of prices (minimum and maximum price).
```
jQuery('#main [itemtype="http://schema.org/Product"] [itemtype="http://schema.org/Offer"] .price .amount')
[<span class=​"amount">​1,00€​</span>​, <span class=​"amount">​2,00€​</span>​]
```

When the all required variations are selected WooCommerce show the total price with a different selector (minimum, maximum and actual).
```
jQuery('#main [itemtype="http://schema.org/Product"]  .price .amount')
[<span class=​"amount">​1,00€​</span>​, <span class=​"amount">​2,00€​</span>​, <span class=​"amount">​1,00€​</span>​]
```