### PR TITLE
Check if ko_redirect_url exists and redirect onDismiss

### DIFF
--- a/demo/checkout-ES.json
+++ b/demo/checkout-ES.json
@@ -3,6 +3,7 @@
   "merchant": {
     "confirmation_url": "/confirm",
     "cancel_url": "/demo-cancel.html",
+    "ko_redirect_url": "/?ko-redirected",
     "success_url": "/demo-success.html"
   },
   "customer": {

--- a/src/apps/checkout-normalizer.js
+++ b/src/apps/checkout-normalizer.js
@@ -38,7 +38,7 @@ function checkoutNormalizer(checkout, location, api) {
   }
   checkout.merchant.onError = checkout.merchant.onError || _locationReplaceFn(location, checkout.merchant.cancel_url);
 
-  checkout.merchant.onDismiss = checkout.merchant.onDismiss || _locationReplaceFn(location, checkout.merchant.checkout_url || '/');
+  checkout.merchant.onDismiss = checkout.merchant.onDismiss || _locationReplaceFn(location, checkout.merchant.ko_redirect_url || checkout.merchant.checkout_url || '/');
 
   if( !checkout.merchant.onPending ) {
     checkout.merchant.onPending = checkout.merchant.pending_url ? _locationReplaceFn(location, checkout.merchant.pending_url) : checkout.merchant.onDismiss;


### PR DESCRIPTION
En el caso de que se informe `ko_redirect_url` y el checkout se cierre por cualquier error (onDismiss) entonces redirige a `ko_redirect_url || checkout_url || '/'`. No se que te parece este planteamiento. 
Entiendo que esto lo tiene que configurar el cliente (https://aplazame.com/docs/api/3-steps-to-checkout/#2-checkout), es asi ?