### PR TITLE
Remove version and checkoutVersion options

### DIFF
--- a/src/core/api-http.js
+++ b/src/core/api-http.js
@@ -7,9 +7,6 @@ var apzVersion = require('../../.tmp/aplazame-version'),
     renderAccept = _.template.compile('application/vnd.aplazame<% if(sandbox){ %>.sandbox<% } %>.v<%= version %>+json'),
     acceptHeader = function (config) {
       var _api = _.copy(api);
-      if( 'version' in config || 'apiVersion' in config ) {
-        _api.version = 'version' in config ? config.version : config.apiVersion;
-      }
       if( 'sandbox' in config ) {
         _api.sandbox = config.sandbox;
       }

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -5,6 +5,5 @@ module.exports = {
   // host: 'https://api.aplazame.com/',
   staticUrl: 'https://aplazame.com/static/',
   version: 1,
-  checkoutVersion: 1,
   sandbox: false
 };

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -7,20 +7,6 @@ var api = require('./api'),
 function init (options) {
   options = options || {};
 
-  if( typeof options.version === 'string' ) {
-    var matchVersion = options.version.match(/^v?(\d)(\.(\d))?$/);
-
-    if( !matchVersion ) {
-      throw new Error('version mismatch, should be like \'v1.2\'');
-    }
-
-    options.version = Number(matchVersion[1]);
-
-    if( matchVersion[3] !== undefined ) {
-      options.checkoutVersion = Number(matchVersion[3]);
-    }
-  }
-
   if( typeof options.sandbox === 'string' ) {
     options.sandbox = options.sandbox === 'true';
   }

--- a/src/loaders/data-aplazame.js
+++ b/src/loaders/data-aplazame.js
@@ -24,10 +24,6 @@ module.exports = function (_, script) {
     options.host = script.getAttribute('data-api-host');
   }
 
-  if( script.getAttribute('data-version') ) {
-    options.version = script.getAttribute('data-version');
-  }
-
   if( script.getAttribute('data-sandbox') ) {
     options.sandbox = script.getAttribute('data-sandbox');
   }


### PR DESCRIPTION
`checkoutVersion` is not longer used and to `version` is not safe as code is tied to an specific version